### PR TITLE
#170023738 Catch 404, 500 and 405 errors

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,8 @@
 import express from 'express';
 import bodyParser from 'body-parser';
 import router from './routes';
+import ErrorHandler from './middlewares/ErrorHandler';
+
 
 const app = express();
 const port = process.env.PORT || 3000;
@@ -9,12 +11,12 @@ const port = process.env.PORT || 3000;
 app.use(bodyParser.urlencoded({ extended: false }));
 app.use(bodyParser.text());
 app.use(bodyParser.json({ type: 'application/json' }));
-app.use('/', router);
-
 app.get('/', (req, res) => res.status(200).send({
   message: 'Welcome to Barefoot Nomad.'
 }));
+app.use('/', router);
 
+app.use('*', ErrorHandler.methodError, ErrorHandler.serverError, ErrorHandler.updateLogFile);
 
 app.listen(port, () => {
   // eslint-disable-next-line no-console

--- a/src/middlewares/ErrorHandler.js
+++ b/src/middlewares/ErrorHandler.js
@@ -1,0 +1,79 @@
+import fs from 'fs';
+import Customize from '../helpers/Customize';
+/**
+ * @export
+ * @class ErrorHandler
+ */
+class ErrorHandler {
+  /**
+     * handle methor errors
+     * @static
+     * @param {object} req request object
+     * @param {object} res response object
+     * @param {object} next next
+     * @memberof UserController
+     * @returns {object} either an error or calls next
+     */
+  static async methodNotCorrect(req, res, next) {
+    const error = new Error('Ooops this method is not allowed');
+    error.status = 405;
+    next(error);
+  }
+
+  /**
+     * handle methor errors
+     * @static
+     * @param {object} req request object
+     * @param {object} res response object
+     * @param {object} next next
+     * @memberof UserController
+     * @returns {object} either an error or calls next
+     */
+  static async methodError(req, res, next) {
+    const error = new Error('Not Found');
+    error.status = 404;
+    next(error);
+  }
+
+  /**
+     * handle server errors
+     * @static
+     * @param {object} error request object
+     * @param {object} req request object
+     * @param {object} res response object
+     * @param {object} next next
+     * @memberof UserController
+     * @returns {object} either an error or calls next
+     */
+  static async serverError(error, req, res, next) {
+    Customize.errorMessage(req, res, error.message, error.status || 500);
+    next(error);
+  }
+
+  /**
+     * writes logs
+     * @static
+     * @param {object} error request object
+     * @param {object} req request object
+     * @param {object} res response object
+     * @param {object} next next
+     * @memberof UserController
+     * @returns {object} either an error or calls next
+     */
+  static async updateLogFile(error, req, res, next) {
+    await fs.appendFile(
+      'error.log',
+      `
+    *******************************************************\n
+    Date: ${new Date(Date.now())}\n
+    Error: ${error.message}\n
+    Status: ${error.status || 500}\n
+    ********************************************************`,
+      (err) => {
+        if (err) throw err;
+      }
+    );
+    next();
+  }
+}
+export default ErrorHandler;

--- a/src/tests/001-erroHandlingTests.js
+++ b/src/tests/001-erroHandlingTests.js
@@ -1,0 +1,17 @@
+import chai from 'chai';
+import chaiHttp from 'chai-http';
+import app from '../index';
+
+chai.use(chaiHttp);
+chai.should();
+const { expect } = chai;
+
+describe('Error handling tests', () => {
+  it('Display a 405 error when the wrong url is provided', (done) => {
+    chai.request(app).post('/api/v1/auth/signupkfnddnf').end((err, res) => {
+      res.should.have.status(404);
+      expect(res.body.message).eql('Not Found');
+      done();
+    });
+  });
+});

--- a/src/tests/010-userTest.js
+++ b/src/tests/010-userTest.js
@@ -33,13 +33,6 @@ describe('Authentication test', () => {
       done();
     });
   });
-  it('should be not able to signup when route path is incorrect', (done) => {
-    chai.request(app).post('/api/v1/auth/signupkfnddnf').end((err, res) => {
-      res.should.have.status(404);
-      res.body.should.be.an('object');
-      done();
-    });
-  });
   it('Test Welcome Page route', (done) => {
     chai.request(app).get('/').end((err, res) => {
       res.should.have.status(200);


### PR DESCRIPTION
### What does this PR do?
Adds a middleware that catches 500 and 405 errors
#### Description of Task to be completed?
- Write tests for 405 errors
- Write a middle ware class that catches 405 and 500 errors
#### How should this be manually tested?
- git clone `https://github.com/andela/team-odd-bn-backend`
- git checkout `ch-error-handling-170023738`
- `npm run dev-start`
- break some thing in the code base to see if 500 error is caught.
- use a wrong url to capture 405 errors.
#### Any background context you want to provide?
#### What are the relevant pivotal tracker stories?
[#170023738](https://www.pivotaltracker.com/n/projects/2407428/stories/170023738)
#### Screenshots (if appropriate)
<img width="1175" alt="Screen Shot 2019-11-29 at 10 05 01" src="https://user-images.githubusercontent.com/45129725/69853522-cf8d7900-128f-11ea-8dab-c019cf9e2029.png">
<img width="1198" alt="Screen Shot 2019-11-29 at 10 05 17" src="https://user-images.githubusercontent.com/45129725/69853523-cf8d7900-128f-11ea-894b-da08feb400dd.png">
<img width="621" alt="Screen Shot 2019-11-29 at 11 37 28" src="https://user-images.githubusercontent.com/45129725/69859371-b17a4580-129c-11ea-8214-07e48f389c5f.png">


#### Questions: