### PR TITLE
#169258662 users should get stats of trips made in the last X timeframe

### DIFF
--- a/src/controllers/TripController.js
+++ b/src/controllers/TripController.js
@@ -127,5 +127,26 @@ class TripController {
       return Response.errorMessage(req, res, 'Oops! internal server error', 500);
     }
   }
+
+  /**
+ * Manager/User should be able to get trip stats he made in X timeframe
+ * @static
+ * @param {object} req request object
+ * @param {object} res response object
+ * @memberof TripController
+ * @returns {object} data
+ * @description PATCH api/v1/trips/requests
+ */
+  static async getTripStatsController(req, res) {
+    try {
+      const { from, to } = req.query;
+      const userTrips = await TripService.getUserTrips(req);
+      const tripsCounter = userTrips.length;
+      const msg = `All one way trips made between ${from} and ${to} retrieved successfully!`;
+      Response.successMessage(req, res, msg, { tripsCounter, userTrips }, 200);
+    } catch (error) {
+      Response.errorMessage(req, res, error.message, 500);
+    }
+  }
 }
 export default TripController;

--- a/src/helpers/TripHelper.js
+++ b/src/helpers/TripHelper.js
@@ -1,6 +1,7 @@
 import Response from './Response';
 import emailHelper from './EmailHelper';
-import { tripRequests, trips } from '../database/models';
+import CommonQueries from '../services/CommonQueries';
+import { tripRequests, trips, cities } from '../database/models';
 
 
 /**
@@ -39,6 +40,19 @@ class TripHelper {
     } catch (err) {
       return Response.errorMessage(req, res, err.message, 500);
     }
+  }
+
+  /**
+  * Should return city names corresponding to both originId and destinationId provided
+  * @static
+  * @param {object} tripTypeId city type ID
+  * @memberof TripController
+  * @returns {object} data
+  */
+  static async getCityName(tripTypeId) {
+    const { dataValues: origin } = await CommonQueries.findOne(cities, { where: { id: tripTypeId.originId }, attributes: ['city'] });
+    const { dataValues: destination } = await CommonQueries.findOne(cities, { where: { id: tripTypeId.destinationId }, attributes: ['city'] });
+    return { origin, destination };
   }
 }
 

--- a/src/middlewares/Validate.js
+++ b/src/middlewares/Validate.js
@@ -234,6 +234,24 @@ class Validate {
   }
 
   /**
+  * Validate trips stats inputs
+  * @static
+  * @returns {object} errors
+  */
+  static tripStatsRules() {
+    const d = new Date();
+    const year = d.getFullYear();
+    const month = d.getMonth();
+    const day = d.getDate();
+    const MaxDate = new Date(year + 20, month, day).toDateString();
+    return [
+      check('tripTypeId', 'trip type id should be an integer(1: One-way, 2: two-way, 3: Multi-city)').isInt(),
+      check('from', 'To date should be valid(YYYY-MM-DD)').isBefore(MaxDate),
+      check('to', 'End date should be valid(YYYY-MM-DD)').isBefore(MaxDate),
+    ];
+  }
+
+  /**
     * Validate rating input
     * @static
     * @returns {object} errors

--- a/src/middlewares/ValidateTrip.js
+++ b/src/middlewares/ValidateTrip.js
@@ -67,6 +67,20 @@ export default class ValidateTrip {
   }
 
   /**
+ * check if fromDate is behind toDate
+ * @static
+ * @param {object} req response Object
+ * @param {object} res request Object
+ * @param {object} next next
+ * @memberof ValidateTrip
+ * @returns {object} data
+ */
+  static async dateValidation(req, res, next) {
+    const { from, to } = req.query;
+    return from < to ? next() : Response.errorMessage(req, res, 'Start date should be less that end date', 400);
+  }
+
+  /**
    * checkMultiCityForSimilarRequests
    * @static
    * @param {object} req response Object

--- a/src/middlewares/customValidator.js
+++ b/src/middlewares/customValidator.js
@@ -36,6 +36,21 @@ class customValidator {
   }
 
   /**
+* Check if the manager has provided user id
+* @static
+* @param {object} req request object
+* @param {object} res response object
+* @param {object} next next
+* @memberof Conflict
+* @returns {object} data
+*/
+  static isUserOrManager(req, res, next) {
+    if (req.user.roleId === 6) { return req.query.user ? next() : Response.errorMessage(req, res, 'Please provide user id if you are a manager', 400); }
+    next();
+  }
+
+
+  /**
    * Validate images
    * @static
    * @param {object} req  request object

--- a/src/routes/api/tripRoute.js
+++ b/src/routes/api/tripRoute.js
@@ -6,8 +6,11 @@ import Validate from '../../middlewares/Validate';
 import checkInputDataError from '../../middlewares/checkInputDataError';
 import Exists from '../../middlewares/Exists';
 import Conflict from '../../middlewares/Conflict';
+import CustomValidator from '../../middlewares/customValidator';
 import isUserVerified from '../../middlewares/isUserVerified';
-import { IsOwnerOfTrip, IsTripApproved, isManagerHasAccess, isManagerOwnsRequest } from '../../middlewares/findUsers';
+import {
+  IsOwnerOfTrip, IsTripApproved, isManagerHasAccess, isManagerOwnsRequest
+} from '../../middlewares/findUsers';
 import VerifyUserRoles from '../../middlewares/VerifyUserRoles';
 import operateAcceptOrReject from '../../middlewares/approveOrReject';
 
@@ -21,7 +24,7 @@ const {
 } = TripController;
 const { isTripRequestFound } = Conflict;
 const {
-  acceptOrRejectRequestsController
+  acceptOrRejectRequestsController, getTripStatsController
 } = TripController;
 
 
@@ -419,6 +422,66 @@ tripRouter
     checkInputDataError, Exists.isTripRequestExist,
     isManagerOwnsRequest, isManagerHasAccess,
     operateAcceptOrReject, acceptOrRejectRequestsController
+  );
+
+/**
+* @swagger
+*
+* /trips/stats/{tripTypeId}:
+*   get:
+*     summary: User/Manager get stats of trips made in X timeframe
+*     description: Trips stats
+*     tags:
+*       - Trip
+*     parameters:
+*      - name: token
+*        in: header
+*        required: true
+*        description: user token
+*        schema:
+*          $ref: '#/components/schemas/Token'
+*      - name: tripTypeId
+*        in: path
+*        required: true
+*        description: trip type id
+*        schema:
+*          $ref: '#/components/schemas/Id'
+*      - name: from
+*        in: query
+*        required: true
+*        description: start date
+*        schema:
+*          type: string
+*      - name: to
+*        in: query
+*        required: true
+*        description: end date
+*        schema:
+*          type: string
+*     responses:
+*       200:
+*         description: Trips stas retieved successfully
+*       400:
+*         description: Invalid input
+*       401:
+*         description: Unauthorized
+*       500:
+*         description: Internal server error
+*/
+/**
+* @swagger
+*  components:
+*    schemas:
+*      Id:
+*        type: integer
+*        example: 1
+*        minimum: 1
+*/
+tripRouter
+  .get(
+    '/stats/:tripTypeId',
+    verifyToken, Validate.tripStatsRules(),
+    checkInputDataError, ValidateTrip.dateValidation, CustomValidator.isUserOrManager, getTripStatsController
   );
 
 export default tripRouter;

--- a/src/tests/060-tripTest.js
+++ b/src/tests/060-tripTest.js
@@ -488,3 +488,81 @@ describe('Users should be able to edit trips', () => {
       });
   });
 });
+
+describe('User stats for trips in X timeframe', () => {
+  it('should return all one-way trips made between 2019-10-01 and 2019-11-30', (done) => {
+    chai.request(app)
+      .get('/api/v1/trips/stats/1?from=2019-10-01&to=2030-11-30')
+      .set('token', token)
+      .end((err, res) => {
+        expect(res.status).eql(200);
+        expect(res.body.message).eql('All one way trips made between 2019-10-01 and 2030-11-30 retrieved successfully!');
+        expect(res.body.data.userTrips.length).eql(2);
+        expect(res.body.data).to.be.an('Object');
+        done(err);
+      });
+  });
+  it('should return all two-way trips made between 2020-01-01 and 2020-12-31', (done) => {
+    chai.request(app)
+      .get('/api/v1/trips/stats/2?from=2020-01-01&to=2020-12-31')
+      .set('token', token)
+      .end((err, res) => {
+        expect(res.status).eql(200);
+        expect(res.body.message).eql('All one way trips made between 2020-01-01 and 2020-12-31 retrieved successfully!');
+        expect(res.body.data.userTrips.length).eql(1);
+        expect(res.body.data).to.be.an('Object');
+        done(err);
+      });
+  });
+  it('should return all multi city trips made between 2020-01-01 and 2020-12-30', (done) => {
+    chai.request(app)
+      .get('/api/v1/trips/stats/2?from=2020-01-01&to=2020-12-30')
+      .set('token', token)
+      .end((err, res) => {
+        expect(res.status).eql(200);
+        expect(res.body.message).eql('All one way trips made between 2020-01-01 and 2020-12-30 retrieved successfully!');
+        expect(res.body.data.userTrips.length).eql(1);
+        done(err);
+      });
+  });
+  it('should not retieve data if manager has not provided user id', (done) => {
+    chai.request(app)
+      .get('/api/v1/trips/stats/2?from=2020-01-01&to=2020-12-30')
+      .set('token', managerToken)
+      .end((err, res) => {
+        expect(res.status).eql(400);
+        expect(res.body.message).eql('Please provide user id if you are a manager');
+        done(err);
+      });
+  });
+  it('manager should get trip stats for a specific user', (done) => {
+    chai.request(app)
+      .get('/api/v1/trips/stats/2?from=2020-01-01&to=2020-12-30&user=1')
+      .set('token', managerToken)
+      .end((err, res) => {
+        expect(res.status).eql(200);
+        expect(res.body.message).eql('All one way trips made between 2020-01-01 and 2020-12-30 retrieved successfully!');
+        done(err);
+      });
+  });
+  it('should not retieve data if fromDate is less than toDate', (done) => {
+    chai.request(app)
+      .get('/api/v1/trips/stats/2?from=2020-01-01&to=2015-12-30')
+      .set('token', managerToken)
+      .end((err, res) => {
+        expect(res.status).eql(400);
+        expect(res.body.message).eql('Start date should be less that end date');
+        done(err);
+      });
+  });
+  it('should not retieve data if user id is invalid', (done) => {
+    chai.request(app)
+      .get('/api/v1/trips/stats/2?from=2020-01-01&to=2025-12-30&user=b')
+      .set('token', managerToken)
+      .end((err, res) => {
+        expect(res.status).eql(500);
+        expect(res.body.message).eql('invalid input syntax for integer: "b"');
+        done(err);
+      });
+  });
+});

--- a/src/tests/100-bookingTest.js
+++ b/src/tests/100-bookingTest.js
@@ -1,16 +1,14 @@
+
 import chai, { expect } from 'chai';
 import chaiHttp from 'chai-http';
 import dotenv from 'dotenv';
 import app from '../index';
 import bookMockData from './mock/BookingsMockData';
 
-
 chai.use(chaiHttp);
 chai.should();
-
 dotenv.config();
 let userToken1;
-
 describe('Book an accomadition facility', () => {
   before((done) => {
     chai.request(app)
@@ -30,7 +28,6 @@ describe('Book an accomadition facility', () => {
         done();
       });
   });
-
   before((done) => {
     chai.request(app)
       .post('/api/v1/trips/oneway')
@@ -73,7 +70,6 @@ describe('Book an accomadition facility', () => {
         done(err);
       });
   });
-
   it('should be able to book an accomadition facility', (done) => {
     chai.request(app).post(`/api/v1/trips/${3}/booking`)
       .set('token', userToken1)
@@ -90,8 +86,8 @@ describe('Book an accomadition facility', () => {
       .set('token', userToken1)
       .send(bookMockData.bookedAccommodation)
       .end((err, res) => {
-        expect(res.body.message).eql('Room booked by other client');
-        res.should.have.status(403);
+        expect(res.body.message).eql('The accommodation has already booked');
+        res.should.have.status(409);
         res.body.should.be.an('object');
         done(err);
       });

--- a/src/tests/mock/BookingsMockData.js
+++ b/src/tests/mock/BookingsMockData.js
@@ -1,7 +1,6 @@
 import dotenv from 'dotenv';
 
 dotenv.config();
-
 const { TEST_PASSWORD_ENV } = process.env;
 const BookingsMockData = {
   userBooker: {
@@ -14,7 +13,6 @@ const BookingsMockData = {
     signupType: 'default',
     createdAt: new Date(),
     updatedAt: new Date()
-
   },
   userSetProfile: {
     gender: 'male',
@@ -34,31 +32,31 @@ const BookingsMockData = {
   },
   bookAccommodation: {
     roomId: 1,
-    checkInDate: '2019-12-10',
-    checkOutDate: '2019-12-17'
+    checkInDate: '2030-11-30',
+    checkOutDate: '2030-12-30'
   },
   bookedAccommodation: {
     roomId: 1,
-    checkInDate: '2019-12-15',
-    checkOutDate: '2019-12-19'
+    checkInDate: '2030-11-30',
+    checkOutDate: '2030-12-30'
   },
   checkInDateGreaterThanCheckOutDate: {
     roomId: 1,
-    checkInDate: '2019-12-15',
-    checkOutDate: '2019-12-10'
+    checkInDate: '2030-12-15',
+    checkOutDate: '2030-12-10'
   },
   checkInDateEqualsToCheckOutDate: {
     roomId: 1,
-    checkInDate: '2019-12-15',
-    checkOutDate: '2019-12-15'
+    checkInDate: '2030-12-15',
+    checkOutDate: '2030-12-15'
   },
   userSign: {
     email: 'test@email.com',
     password: TEST_PASSWORD_ENV
   },
   noRoomIdProvided: {
-    checkInDate: '2019-12-10',
-    checkOutDate: '2019-12-17'
+    checkInDate: '2030-12-10',
+    checkOutDate: '2030-12-17'
   },
 };
 export default BookingsMockData;


### PR DESCRIPTION
#### What does this PR do?
This PR adds user functionality to get trips made in a specific timeframe
#### Description of Task to be completed?
Users can are able to retrieve all trips made in X timeframe
#### How should this be manually tested?
Open your terminal and follow these steps
- `clone` or [Download](https://github.com/andela/team-odd-bn-backend/archive/ft-user-trip-stats-169258662.zip) this project
- Open a terminal from the project directory
- Run `npm install` to install all dependencies
- Update migration `npm run db-migrate`
- Populate the seed data `npm run db-seed-dev`
- Run `npm run test` to automatically test all endpoints
- OR run `npm run dev-start` to start the server
- Open `Postman` app

- Navigate to `localhost:{server_port}/api/v1/trips/stats/{tripsType}`
- provide `from` param with `start date` and `to` param with `end date date` 
example: your URL should look like this:
`localhost:{server_port}/api/trips/stats/2?from=20-01-01&to=2020-12-30`
#### Any background context you want to provide?
N/A
#### What are the relevant pivotal tracker stories?
[#169258662](https://www.pivotaltracker.com/story/show/169258662)
#### Screenshots (if appropriate)
##### Manager request
<img width="1139" alt="Screen Shot 2019-12-11 at 13 38 04" src="https://user-images.githubusercontent.com/35301129/70633426-3a986180-1c39-11ea-82fa-f02dcdfb64c3.png">

##### User request
<img width="1133" alt="Screen Shot 2019-12-11 at 13 38 47" src="https://user-images.githubusercontent.com/35301129/70633428-3b30f800-1c39-11ea-84d5-6780eed9ffb0.png">

##### Documentation
<img width="1411" alt="Screen Shot 2019-12-11 at 17 09 41" src="https://user-images.githubusercontent.com/35301129/70633456-42f09c80-1c39-11ea-9917-5df71a352780.png">

#### Questions:
N/A