### PR TITLE
#170230517 Display all notification for a specific user

### DIFF
--- a/src/controllers/UserController.js
+++ b/src/controllers/UserController.js
@@ -6,6 +6,7 @@ import emailHelper from '../helpers/EmailHelper';
 import AuthenticateToken from '../helpers/AuthenticateToken';
 import UserService from '../services/UserService';
 import UserHelper from '../helpers/UserHelper';
+import NotificationService from '../services/NotificationService';
 
 const { hashPassword } = HashPassword;
 const { getAUser } = UserService;
@@ -205,6 +206,19 @@ class UserController {
     const userData = await UserService.viewProfile(req);
 
     return Response.successMessage(req, res, 'User profile retrieved successfully', userData, HttpStatus.OK);
+  }
+
+  /**
+    * User can view his/her specific notification
+    * @description GET /api/v1/users/notification
+    * @static
+    * @param {object} req request object
+    * @param {object} res response object
+    * @returns {object} view notifications
+  */
+  static async viewNotification(req, res) {
+    const notification = await NotificationService.viewNotification(req);
+    return Response.successMessage(req, res, 'Available notification', notification, HttpStatus.OK);
   }
 }
 

--- a/src/database/models/notifications.js
+++ b/src/database/models/notifications.js
@@ -3,7 +3,6 @@ module.exports = (sequelize, DataTypes) => {
   const notifications = sequelize.define('notifications', {
     userId: DataTypes.INTEGER,
     bookingId:DataTypes.INTEGER,
-    managerId: DataTypes.INTEGER,
     tripRequestId: DataTypes.INTEGER,
     message: DataTypes.TEXT,
     markRead: DataTypes.BOOLEAN

--- a/src/routes/api/userRoute.js
+++ b/src/routes/api/userRoute.js
@@ -127,6 +127,28 @@ const { isImage } = customValidator;
 *       500:
 *         description: Internal server error
 */
+
+/**
+ * @swagger
+ *
+ * /users/notification:
+ *    get:
+ *      summary: Available notification for a specific user
+ *      tags: [Notifications]
+ *      parameters:
+ *        - name: token
+ *          in: header
+ *          description: enter token
+ *          required: true
+ *          schema:
+ *            type: string
+ *      responses:
+ *        "200":
+ *          description: Available notifications
+ *        "404":
+ *          description: Notification not found
+ */
 userRoute.put('/profile-settings', verifyToken, profileUpdateRules(), checkInputDataError, isImage, isManager, isUserVerified, UserController.updateProfile);
 userRoute.get('/view-profile', verifyToken, isUserVerified, UserController.viewProfile);
+userRoute.get('/notification', verifyToken, isUserVerified, UserController.viewNotification);
 export default userRoute;

--- a/src/services/NotificationService.js
+++ b/src/services/NotificationService.js
@@ -256,6 +256,31 @@ class NotificationService {
       });
     });
   }
+
+  /**
+  * User can view his/her notification
+  * @description GET /api/v1/users/notification
+  * @static
+  * @param {object} req request object
+  * @returns {object} NotificationService
+  */
+  static async viewNotification(req) {
+    const { id } = req.user;
+    const findAllNotificationObject = {
+      where: {
+        userId: id
+      },
+      order: [
+        ['id', 'DESC'],
+      ],
+    };
+    const result = await CommonQueries.findAll(notifications, findAllNotificationObject);
+
+    if (result.length === 0) {
+      return 'no new notification';
+    }
+    return result;
+  }
 }
 
 export default NotificationService;

--- a/src/tests/090-notification.js
+++ b/src/tests/090-notification.js
@@ -1,0 +1,32 @@
+import chai from 'chai';
+import app from '../index';
+import mockData from './mock/mockData';
+
+const { expect } = chai;
+
+
+let managerToken;
+describe('Expect to display all notifications', () => {
+  before((done) => {
+    chai.request(app)
+      .post('/api/v1/auth/signin')
+      .send(mockData.isManager)
+      .end((err, res) => {
+        managerToken = res.body.data;
+        done(err);
+      });
+  });
+
+  it('It should retrieve all notification successfully', (done) => {
+    chai.request(app)
+      .get('/api/v1/users/notification')
+      .set('token', managerToken)
+      .end((err, res) => {
+        expect(res.status).eql(200);
+        expect(res.body.message).eql('Available notification');
+        expect(res.body).have.property('data');
+        expect(res.body.data).to.be.an('array');
+        done(err);
+      });
+  });
+});


### PR DESCRIPTION
#### What does this PR do?
The PR displays all notifications for a specific user

#### Description of Task to be completed?
#####  **Acceptance Criteria**
- Notification for new comment
- Notification for a trip
- Notification for a booking
- Notification for accommodation.


#### How should this be manually tested?
- Open your terminal
- `git clone https://github.com/andela/team-odd-bn-backend.git`
- `cd team-odd-bn-backend`
- `git checkout ft-all-user-notification-170230517`
- Make sure your `.env` file is updated.
- Run migrations `npm run db-migrate`
- Run `psql`  ([Download](https://www.postgresql.org/download/) if it's not installed)
- Run `\c barefoot_nomad_test_db` to connect to the database
- Run `SELECT * FROM {tableName}`
- OR `select * from INFORMATION_SCHEMA.TABLE_CONSTRAINTS;` to see the schema

#### Any background context you want to provide?
No

#### What are the relevant pivotal tracker stories?
[#170230517](https://www.pivotaltracker.com/story/show/170230517)

#### Screenshots (if appropriate)
All notification
<img width="1440" alt="Screen Shot 2019-12-11 at 08 50 31" src="https://user-images.githubusercontent.com/56690376/70600089-7e6a7700-1bf7-11ea-9bf0-d1c3bad92047.png">

Documentation
<img width="1440" alt="Screen Shot 2019-12-11 at 16 14 30" src="https://user-images.githubusercontent.com/56690376/70628871-9eb72780-1c31-11ea-80c2-937c5a2cd653.png">

#### Questions: