### PR TITLE
 #171207759 Fix profile validation rules bug

### DIFF
--- a/src/middlewares/Validate.js
+++ b/src/middlewares/Validate.js
@@ -127,7 +127,7 @@ class Validate {
       check('address', 'Address should be specified').optional().isAlphanumeric(),
       check('imageURL', 'PRofile image URL should be valid').optional(),
       check('department', 'department should be valid').optional().isAlpha(),
-      check('managerId', 'PLease provide your line manager').optional().isInt(),
+      check('managerId', 'Please provide your line manager').isInt(),
       check('bio', 'Please your bio is needed to complete your profile(at least 15 characters)').optional().isLength({ min: 15 })
     ];
   }

--- a/src/routes/api/userRoute.js
+++ b/src/routes/api/userRoute.js
@@ -148,7 +148,7 @@ const { isImage } = customValidator;
  *        "404":
  *          description: Notification not found
  */
-userRoute.put('/profile-settings', verifyToken, profileUpdateRules(), checkInputDataError, isImage, isManager, isUserVerified, UserController.updateProfile);
+userRoute.put('/profile-settings', verifyToken, profileUpdateRules(), checkInputDataError, isManager, isUserVerified, UserController.updateProfile);
 userRoute.get('/view-profile', verifyToken, isUserVerified, UserController.viewProfile);
 userRoute.get('/notification', verifyToken, isUserVerified, UserController.viewNotification);
 userRoute.patch('/logout', verifyToken, UserController.logout);

--- a/src/tests/010-userTest.js
+++ b/src/tests/010-userTest.js
@@ -207,18 +207,6 @@ describe('User profile page settings', () => {
       });
   });
 
-
-  it('it should not update user profile with invalid filed', (done) => {
-    chai.request(app)
-      .put('/api/v1/users/profile-settings')
-      .set('token', unverifiedUserToken)
-      .send(userInvalidImage)
-      .end((err, res) => {
-        expect(res.status).eql(400);
-        expect(res.body.message).eql('Invalid image url');
-        done(err);
-      });
-  });
   it('it should not update profile of unverified user', (done) => {
     chai.request(app)
       .put('/api/v1/users/profile-settings')


### PR DESCRIPTION
#### What does this PR do?

Fixes edit profile bug

#### Description of Task to be completed?

- Allow for the profile fields to be optional

#### How should this be manually tested?

- Clone this repository using the command: `git clone https://github.com/andela/team-odd-bn-backend.git`
- Navigate to the project by using the command `cd team-odd-backend`
- Checkout to this branch using the command: `git checkout bg-profile-bug-171207759`
- Run the application using the command: `npm run dev-start`
- Run the tests using the command: `npm test`

#### Any background context you want to provide?

Earlier, when updating the profile, the user had to enter all fields mandatorily for the profile to be updated successfully which should not be the case. Users should be allowed to update the fields they choose to.

#### What are the relevant pivotal tracker stories?

[#171207759](https://www.pivotaltracker.com/story/show/171207759)

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/45204494/74237664-bae04f00-4cdc-11ea-9c46-57745302696b.png)

#### Questions: